### PR TITLE
Remove buildpack code; add build script

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: MIX_ENV=prod mix phx.server

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+npm install
+npm run build
+mix do deps.get, deps.compile, compile, phx.digest

--- a/compile
+++ b/compile
@@ -1,9 +1,0 @@
-MIX_ENV=prod npm run build
-
-cd $phoenix_dir
-
-mix "${phoenix_ex}.digest"
-
-if mix help "${phoenix_ex}.digest.clean" 1>/dev/null 2>&1; then
-  mix "${phoenix_ex}.digest.clean"
-fi

--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,1 +1,0 @@
-elixir_version=(branch v1.6)


### PR DESCRIPTION
This gets rid of the Heroku buildpack dependency and lets you deploy on Cove straight from GitHub.