### PR TITLE
Update PageControllerTest

### DIFF
--- a/test/elixir_formatter_web/controllers/page_controller_test.exs
+++ b/test/elixir_formatter_web/controllers/page_controller_test.exs
@@ -2,7 +2,7 @@ defmodule ElixirFormatterWeb.PageControllerTest do
   use ElixirFormatterWeb.ConnCase
 
   test "GET /", %{conn: conn} do
-    conn = get conn, "/"
-    assert html_response(conn, 200) =~ "Welcome to Phoenix!"
+    conn = get(conn, "/")
+    assert html_response(conn, 200) =~ "Elixir Formatter"
   end
 end


### PR DESCRIPTION
`PageControllerTest`'s only test was the one generated alongside the Phoenix scaffold, testing that the generated home/index page said "Welcome to Phoenix". Since this page was updated to be the home/main page for the formatter website, its contents no longer contain "Welcome to Phoenix" and the test was broken. I updated the test to check the index page for the text "Elixir Formatter".

_Is this test useful?_
I believe so. While the actual contents of the page is relatively unimportant, this test is primarily a measure of the app's basic health. If this test passes, then the app's configuration is valid and the server is able to start.